### PR TITLE
feat: allow configurable MQTT retain

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,12 @@ The configuration file has to be located in the same directory as the installati
 
 __An example of a correct configuration file is found in [```config.example.json```](https://github.com/timroemisch/mqtt-s7-connector/blob/master/config.example.json).__
 
-The config file has to be valid JSON (You can check [here](https://jsonformatter.curiousconcept.com/) if it´s correct)  
-and is separated in 3 sections:
+The config file has to be valid JSON (You can check [here](https://jsonformatter.curiousconcept.com/) if it´s correct)
+and may include optional top-level settings such as:
+
+* `retain_messages` - publish MQTT updates with the retain flag (`false` by default)
+
+It is separated in 3 sections:
 
 * plc:  
 > __general setup of the connection to the plc__  

--- a/attribute.js
+++ b/attribute.js
@@ -1,9 +1,9 @@
 let sf = require("./service_functions.js");
 
 module.exports = class attribute {
-	constructor(plc, mqtt, name, type, mqtt_device_topic) {
-		this.plc_handler = plc;
-		this.mqtt_handler = mqtt;
+        constructor(plc, mqtt, name, type, mqtt_device_topic, retain_messages = false) {
+                this.plc_handler = plc;
+                this.mqtt_handler = mqtt;
 
 		this.last_update = 0;
 		this.last_value = 0;
@@ -38,8 +38,11 @@ module.exports = class attribute {
 		// full topic
 		this.full_mqtt_topic = mqtt_device_topic + "/" + this.name;
 
-		// optional write back changes from plc to set_plc
-		this.write_back = false;
+                // optional write back changes from plc to set_plc
+                this.write_back = false;
+
+                // set retain option for mqtt messages
+                this.retain_messages = retain_messages;
 
 		// only subscribe if attribute is allowed to write to plc
 		if (this.write_to_s7) {
@@ -128,9 +131,9 @@ module.exports = class attribute {
 				this.last_value = data;
 				this.last_update = now;
 
-				this.mqtt_handler.publish(this.full_mqtt_topic, data.toString(), {
-					retain: false
-				});
+                                this.mqtt_handler.publish(this.full_mqtt_topic, data.toString(), {
+                                        retain: this.retain_messages
+                                });
 
 				if (this.write_back) {
 					if (data == this.last_set_data) {

--- a/device.js
+++ b/device.js
@@ -2,16 +2,19 @@ let attribute = require("./attribute.js");
 let sf = require('./service_functions.js');
 
 module.exports = class device {
-	constructor(plc, mqtt, config) {
-		this.plc_handler = plc;
-		this.mqtt_handler = mqtt;
+        constructor(plc, mqtt, config) {
+                this.plc_handler = plc;
+                this.mqtt_handler = mqtt;
 
-		this.name = config.name || "unnamed device";
-		this.config = config;
+                this.name = config.name || "unnamed device";
+                this.config = config;
 
-		this.discovery_topic = "homeassistant";
-		this.discovery_retain = false;
-		this.type = config.type.toLowerCase();
+                this.discovery_topic = "homeassistant";
+                this.discovery_retain = false;
+                this.type = config.type.toLowerCase();
+
+                // retain option for mqtt messages
+                this.retain_messages = config.retain_messages || false;
 
 		// device topics
 		this.mqtt_name = config.mqtt;
@@ -23,12 +26,13 @@ module.exports = class device {
 
 	create_attribute(config, required_type, name) {
 		// create attribute object
-		let new_attribute = new attribute(
-			this.plc_handler,
-			this.mqtt_handler,
-			name,
-			required_type,
-			this.full_mqtt_topic);
+                let new_attribute = new attribute(
+                        this.plc_handler,
+                        this.mqtt_handler,
+                        name,
+                        required_type,
+                        this.full_mqtt_topic,
+                        this.retain_messages);
 
 		// the config could be an object
 		// or simply an string

--- a/deviceFactory.js
+++ b/deviceFactory.js
@@ -9,7 +9,7 @@ let dev_switch = require('./devices/switch.js');
 let dev_climate = require('./devices/climate.js');
 let dev_binCover = require('./devices/binaryCover.js');
 
-module.exports = function deviceFactory(devices, plc, mqtt, config, mqtt_base) {
+module.exports = function deviceFactory(devices, plc, mqtt, config, mqtt_base, retain_messages) {
 	let type = config.type.toLowerCase();
 
 	// check name
@@ -37,9 +37,10 @@ module.exports = function deviceFactory(devices, plc, mqtt, config, mqtt_base) {
 	// save new values back to config
 	// so it can be processed in the new object
 	mqtt_name = new_mqtt_name;
-	config.name = name;
-	config.mqtt = new_mqtt_name;
-	config.mqtt_base = mqtt_base;
+        config.name = name;
+        config.mqtt = new_mqtt_name;
+        config.mqtt_base = mqtt_base;
+        config.retain_messages = retain_messages;
 
 	switch (type) {
 		case "light":

--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ function init() {
 			// create for each config entry an object
 			// and save it to the array
 			config.devices.forEach((dev) => {
-				let new_device = deviceFactory(devices, plc, mqtt, dev, config.mqtt_base);
+                                let new_device = deviceFactory(devices, plc, mqtt, dev, config.mqtt_base, config.retain_messages);
 
 				// perform discovery message
 				new_device.discovery_topic = config.discovery_prefix;

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "s7-mqtt-connector": "index.js"
   },
   "scripts": {
-    "test": "node test/retain.test.js",
+    "test": "node --test",
     "start": "node index.js"
   },
   "author": "timroemisch https://github.com/timroemisch",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "s7-mqtt-connector": "index.js"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node test/retain.test.js",
     "start": "node index.js"
   },
   "author": "timroemisch https://github.com/timroemisch",

--- a/test/attribute-format.test.js
+++ b/test/attribute-format.test.js
@@ -1,0 +1,45 @@
+const test = require('node:test');
+const assert = require('assert');
+const Attribute = require('../attribute.js');
+
+function createAttr() {
+  const mqtt = { subscribe: () => {}, publish: () => {}, unsubscribe: () => {} };
+  const plc = { addItems: () => {}, writeItems: () => {} };
+  return new Attribute(plc, mqtt, 'attr', 'X', 'dev');
+}
+
+test('formatMessage parses boolean true/false', () => {
+  const attr = createAttr();
+  assert.deepStrictEqual(attr.formatMessage('true', 'X'), [0, true]);
+  assert.deepStrictEqual(attr.formatMessage('false', 'X'), [0, false]);
+});
+
+test('formatMessage rejects invalid boolean', () => {
+  const attr = createAttr();
+  assert.deepStrictEqual(attr.formatMessage('foo', 'X'), [-2]);
+});
+
+test('formatMessage parses BYTE integer', () => {
+  const attr = createAttr();
+  assert.deepStrictEqual(attr.formatMessage('10', 'BYTE'), [0, 10]);
+});
+
+test('formatMessage rejects invalid BYTE', () => {
+  const attr = createAttr();
+  assert.deepStrictEqual(attr.formatMessage('bar', 'BYTE'), [-2]);
+});
+
+test('formatMessage parses REAL float', () => {
+  const attr = createAttr();
+  assert.deepStrictEqual(attr.formatMessage('1.23', 'REAL'), [0, 1.23]);
+});
+
+test('formatMessage rejects invalid REAL', () => {
+  const attr = createAttr();
+  assert.deepStrictEqual(attr.formatMessage('baz', 'REAL'), [-2]);
+});
+
+test('formatMessage returns error for unknown type', () => {
+  const attr = createAttr();
+  assert.deepStrictEqual(attr.formatMessage('1', 'WORD'), [-1]);
+});

--- a/test/device.test.js
+++ b/test/device.test.js
@@ -1,0 +1,40 @@
+const test = require('node:test');
+const assert = require('assert');
+const Device = require('../device.js');
+
+function createDevice() {
+  const mqtt = { publish: () => {}, subscribe: () => {}, unsubscribe: () => {} };
+  const plc = { addItems: () => {}, writeItems: () => {} };
+  const config = { type: 'sensor', name: 'Dev', mqtt: 'dev', mqtt_base: 'base' };
+  return new Device(plc, mqtt, config);
+}
+
+test('get_plc_address returns configured address', () => {
+  const dev = createDevice();
+  dev.create_attribute({ plc: 'DB1,REAL0', set_plc: 'DB1,REAL4' }, 'REAL', 'temp');
+  assert.strictEqual(dev.get_plc_address('temp'), 'DB1,REAL0');
+});
+
+test('get_plc_set_address prefers set_plc when provided', () => {
+  const dev = createDevice();
+  dev.create_attribute({ plc: 'DB1,REAL0', set_plc: 'DB1,REAL4' }, 'REAL', 'temp');
+  assert.strictEqual(dev.get_plc_set_address('temp'), 'DB1,REAL4');
+});
+
+test('get_plc_set_address falls back to plc address', () => {
+  const dev = createDevice();
+  dev.create_attribute('DB1,REAL8', 'REAL', 'temp');
+  assert.strictEqual(dev.get_plc_set_address('temp'), 'DB1,REAL8');
+});
+
+test('getters return null for unknown attribute', () => {
+  const dev = createDevice();
+  assert.strictEqual(dev.get_plc_address('unknown'), null);
+  assert.strictEqual(dev.get_plc_set_address('unknown'), null);
+});
+
+test('create_attribute rejects wrong type', () => {
+  const dev = createDevice();
+  dev.create_attribute('DB1,X0.0', 'REAL', 'flag');
+  assert.strictEqual(dev.attributes.flag, undefined);
+});

--- a/test/deviceFactory.test.js
+++ b/test/deviceFactory.test.js
@@ -1,0 +1,21 @@
+const test = require('node:test');
+const assert = require('assert');
+const deviceFactory = require('../deviceFactory.js');
+
+function createMocks() {
+  return {
+    mqtt: { publish: () => {}, subscribe: () => {}, unsubscribe: () => {} },
+    plc: { addItems: () => {}, writeItems: () => {} }
+  };
+}
+
+test('deviceFactory generates unique mqtt names', () => {
+  const { mqtt, plc } = createMocks();
+  const devices = {};
+  const config1 = { type: 'sensor', name: 'Temp', state: { plc: 'DB1,REAL0' } };
+  const dev1 = deviceFactory(devices, plc, mqtt, config1, 'base', false);
+  devices[dev1.mqtt_name] = dev1;
+  const config2 = { type: 'sensor', name: 'Temp', state: { plc: 'DB1,REAL4' } };
+  const dev2 = deviceFactory(devices, plc, mqtt, config2, 'base', false);
+  assert.strictEqual(dev2.mqtt_name, 'temp-1');
+});

--- a/test/retain.test.js
+++ b/test/retain.test.js
@@ -1,3 +1,4 @@
+const test = require('node:test');
 const assert = require('assert');
 const Attribute = require('../attribute.js');
 const deviceFactory = require('../deviceFactory.js');
@@ -17,7 +18,7 @@ function createMocks() {
   };
 }
 
-function testAttributeRetainTrue() {
+test('attribute publishes with retain', () => {
   const { mqtt, plc } = createMocks();
   let call;
   mqtt.publish = (topic, message, options) => {
@@ -30,9 +31,9 @@ function testAttributeRetainTrue() {
     message: 'true',
     options: { retain: true }
   });
-}
+});
 
-function testAttributeRetainFalse() {
+test('attribute publishes without retain', () => {
   const { mqtt, plc } = createMocks();
   let call;
   mqtt.publish = (topic, message, options) => {
@@ -45,36 +46,12 @@ function testAttributeRetainFalse() {
     message: 'true',
     options: { retain: false }
   });
-}
+});
 
-function testDeviceFactoryPropagation() {
+test('deviceFactory propagates retain flag', () => {
   const { mqtt, plc } = createMocks();
   const config = { type: 'sensor', name: 'Temp', state: { plc: 'DB1,REAL0' } };
   const devices = {};
   const dev = deviceFactory(devices, plc, mqtt, config, 'base', true);
   assert.strictEqual(dev.attributes.state.retain_messages, true);
-}
-
-const tests = [
-  ['attribute publishes with retain', testAttributeRetainTrue],
-  ['attribute publishes without retain', testAttributeRetainFalse],
-  ['deviceFactory propagates retain flag', testDeviceFactoryPropagation]
-];
-
-let failed = false;
-for (const [name, fn] of tests) {
-  try {
-    fn();
-    console.log(`✓ ${name}`);
-  } catch (err) {
-    failed = true;
-    console.error(`✗ ${name}`);
-    console.error(err);
-  }
-}
-
-if (failed) {
-  process.exit(1);
-} else {
-  console.log('All tests passed');
-}
+});

--- a/test/retain.test.js
+++ b/test/retain.test.js
@@ -1,0 +1,80 @@
+const assert = require('assert');
+const Attribute = require('../attribute.js');
+const deviceFactory = require('../deviceFactory.js');
+
+// Helper mocks
+function createMocks() {
+  return {
+    mqtt: {
+      subscribe: () => {},
+      publish: () => {},
+      unsubscribe: () => {}
+    },
+    plc: {
+      addItems: () => {},
+      writeItems: () => {}
+    }
+  };
+}
+
+function testAttributeRetainTrue() {
+  const { mqtt, plc } = createMocks();
+  let call;
+  mqtt.publish = (topic, message, options) => {
+    call = { topic, message, options };
+  };
+  const attr = new Attribute(plc, mqtt, 'state', 'X', 'device', true);
+  attr.rec_s7_data(true);
+  assert.deepStrictEqual(call, {
+    topic: 'device/state',
+    message: 'true',
+    options: { retain: true }
+  });
+}
+
+function testAttributeRetainFalse() {
+  const { mqtt, plc } = createMocks();
+  let call;
+  mqtt.publish = (topic, message, options) => {
+    call = { topic, message, options };
+  };
+  const attr = new Attribute(plc, mqtt, 'state', 'X', 'device', false);
+  attr.rec_s7_data(true);
+  assert.deepStrictEqual(call, {
+    topic: 'device/state',
+    message: 'true',
+    options: { retain: false }
+  });
+}
+
+function testDeviceFactoryPropagation() {
+  const { mqtt, plc } = createMocks();
+  const config = { type: 'sensor', name: 'Temp', state: { plc: 'DB1,REAL0' } };
+  const devices = {};
+  const dev = deviceFactory(devices, plc, mqtt, config, 'base', true);
+  assert.strictEqual(dev.attributes.state.retain_messages, true);
+}
+
+const tests = [
+  ['attribute publishes with retain', testAttributeRetainTrue],
+  ['attribute publishes without retain', testAttributeRetainFalse],
+  ['deviceFactory propagates retain flag', testDeviceFactoryPropagation]
+];
+
+let failed = false;
+for (const [name, fn] of tests) {
+  try {
+    fn();
+    console.log(`✓ ${name}`);
+  } catch (err) {
+    failed = true;
+    console.error(`✗ ${name}`);
+    console.error(err);
+  }
+}
+
+if (failed) {
+  process.exit(1);
+} else {
+  console.log('All tests passed');
+}


### PR DESCRIPTION
## Summary
- allow enabling MQTT message retention via `retain_messages` config option
- propagate retain setting from config through device factory down to attributes
- document `retain_messages` in README

## Testing
- `npm test` *(fails: Error: no test specified)*
