### PR TITLE
chore: expand docker publish triggers

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,8 +1,11 @@
 name: Publish Docker image
 
 on:
+  push:
+    tags:
+      - '*'
   release:
-    types: [published]
+    types: [published, released]
 
 jobs:
   docker:


### PR DESCRIPTION
## Summary
- run Docker publish workflow on tag pushes and release events

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68addf2331d0832281997707ee0a5f65